### PR TITLE
Add AI call service blueprint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables
+SIP_USERNAME=niorlusx_sip
+SIP_PASSWORD=changeme

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,16 @@
+name: Deploy
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Run tests
+        run: echo "No tests" 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.env
+call_logs.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,108 @@
-# niorlusx_analytics_service
+# Niorlusx AI Call Service
+
+This repository contains a blueprint for running an AI-powered voice service using a premium-rate phone number. It covers carrier aggregator setup, SIP domain configuration, real-time call metrics, and deployment basics.
+
+## Carrier Aggregator Integration
+
+1. **Choose your aggregator** (e.g., mVoice, Red Telecom, Boku).
+2. Apply as a premium service provider and submit business details.
+3. Once approved, you receive a premium-rate number (e.g., `190x`).
+4. Configure payout bank details for Australian transfers.
+
+```python
+print("[DEBUG] Selected aggregator and started registration.")
+print("[DEBUG] Configuring premium-rate number and SIP trunk.")
+print("[DEBUG] Pricing announcement setup step.")
+```
+
+Pricing disclosure must be played to callers, for example `$4.95 per minute`.
+
+## SIP Step-by-Step Cheat Sheet
+
+1. In the Twilio Console, create a SIP domain named `niorlusx-voice-service`.
+2. Set up authentication with an IP ACL or `niorlusx_sip` username and password.
+3. Point the Voice URL to `https://your-server-domain/voice`.
+4. Configure inbound calls to connect to your AI backend.
+
+```python
+print("[DEBUG] Starting SIP domain setup in Twilio.")
+print("[DEBUG] SIP domain configured with authentication.")
+```
+
+## Real-Time Call Metrics Tracking
+
+Basic logging is handled in `app.py`:
+
+```python
+from datetime import datetime
+
+@app.post("/voice", response_class=PlainTextResponse)
+async def voice_reply(SpeechResult: str = Form(None)):
+    print(f"[DEBUG] Received SpeechResult: {SpeechResult}")
+    log_entry = f"[{datetime.utcnow()}] Incoming text: {SpeechResult}"
+    with open("call_logs.txt", "a") as log_file:
+        log_file.write(log_entry + "\n")
+    # additional AI logic here
+```
+
+A future dashboard could use Grafana or a web UI to display metrics.
+
+```python
+print("[DEBUG] Metrics dashboard placeholder added.")
+```
+
+## Repository Structure
+
+```
+app.py
+requirements.txt
+.env.example
+start.sh
+README.md
+twiml.xml
+Dockerfile
+.github/workflows/deploy.yml
+(call_logs.txt created at runtime)
+```
+
+## Development and Deployment
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the server locally:
+   ```bash
+   bash start.sh
+   ```
+3. Push code to GitHub:
+   ```bash
+   git add .
+   git commit -m "Add carrier aggregator docs, SIP cheat sheet, metrics tracking"
+   git push origin main
+   ```
+
+```python
+print("[DEBUG] Preparing to push code to GitHub.")
+```
+
+## Demo Setup
+
+1. Start the local server with `bash start.sh` or `uvicorn app:app --host 0.0.0.0 --port 8000`.
+2. Connect Twilio SIP to `https://your-server-domain/voice`.
+3. Dial the premium number from a phone and interact with the AI.
+4. Logs appear in `call_logs.txt`.
+
+```python
+print("[DEBUG] Starting local server and connecting SIP.")
+```
+
+## Next Add-ons
+
+- SMS fallback or dual-mode billing.
+- Automated refunds or compliance scripts.
+- Memory storage per caller (user profile).
+
+```python
+print("[DEBUG] Next add-ons listed for future implementation.")
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,18 @@
+from fastapi import FastAPI, Form
+from fastapi.responses import PlainTextResponse
+from datetime import datetime
+
+app = FastAPI()
+
+@app.post("/voice", response_class=PlainTextResponse)
+async def voice_reply(SpeechResult: str = Form(None)):
+    print(f"[DEBUG] Received SpeechResult: {SpeechResult}")
+    log_entry = f"[{datetime.utcnow()}] Incoming text: {SpeechResult}"
+    with open("call_logs.txt", "a") as log_file:
+        log_file.write(log_entry + "\n")
+    return "Processed"
+
+if __name__ == "__main__":
+    import uvicorn
+    print("[DEBUG] Starting local server and connecting SIP.")
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+python-multipart

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+uvicorn app:app --host 0.0.0.0 --port 8000

--- a/twiml.xml
+++ b/twiml.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+    <Say>Thank you for calling Niorlusx AI service.</Say>
+    <Pause length="1"/>
+    <Say>Please hold while we connect your call.</Say>
+</Response>


### PR DESCRIPTION
## Summary
- add docs for carrier aggregator setup
- add SIP domain cheat sheet and metrics snippet
- implement FastAPI server with basic /voice endpoint
- provide Dockerfile, GitHub Actions workflow, and start script

## Testing
- `python -m py_compile app.py`
- `timeout 1 bash start.sh` (fails until installing dependencies)
- `pip install -r requirements.txt`
- `timeout 1 bash start.sh`

------
https://chatgpt.com/codex/tasks/task_e_6880412e7a94832b8fddbd58b6cd35a1